### PR TITLE
fix: force spawn to use powershell on windows and fixed drive case match

### DIFF
--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -101,7 +101,7 @@ export class TestRunner {
         cwd: workspacePath,
         stdio: ["ignore", "pipe", "pipe"],
         env,
-        shell: isWindows,
+        shell: isWindows ? 'powershell' : false,
       });
 
       for await (const line of chunksToLinesAsync(child.stdout)) {

--- a/src/runHandler.ts
+++ b/src/runHandler.ts
@@ -122,7 +122,11 @@ async function runTest(
   for (const file of fileItems) {
     pathToFile.set(file.uri!.fsPath, file);
     if (isWindows) {
-      pathToFile.set(file.uri!.fsPath.replace(/\\/g, "/"), file);
+      let windowsPath = file.uri!.fsPath.replace(/\\/g, "/");
+      // vscode sends path with lowercase for drive, but tests report with uppercase
+      // so there are no matches unless this is adjusted
+      windowsPath = windowsPath.charAt(0).toUpperCase() + windowsPath.slice(1);
+      pathToFile.set(windowsPath, file);
     }
   }
 


### PR DESCRIPTION
This PR fixes the issue that I had in #8 on my Windows machine. 

The first part is forcing the shell to be `powershell` rather than the default value of `true`, which I'm guessing uses `cmd` (I couldn't find any good docs on that). I don't think this should cause any issues on other Windows machines, but I'm unable to test.

The second part is that the tests report their results in the file as `X:/path_to_test`, but the `vscode.TestItem[]` seems to input the files with a lowercase `x:/path_to_test`, so I correct it in the Windows part of the `pathToFile` map to allow the tests to be correctly identified.