### PR TITLE
fix: use 'node vitest.mjs' as default vitest command on windows

### DIFF
--- a/src/pure/runner.ts
+++ b/src/pure/runner.ts
@@ -69,7 +69,9 @@ export class TestRunner {
     log: (msg: string) => void = () => {},
     workspaceEnv: Record<string, string> = {},
     vitestCommand: string[] = this.vitestPath
-      ? [this.vitestPath]
+      ? isWindows
+        ? ["node", this.vitestPath]
+        : [this.vitestPath]
       : ["npx", "vitest"],
   ): Promise<FormattedTestResults> {
     if (isWindows) {


### PR DESCRIPTION
This PR fixes a small bug on Windows (with default settings).

Without any settings, the vitestCommand in `TestRunner`  class will be a `.mjs` file, which is not callable on windows.  So I change it to `node vitest.mjs` on windows by default, and on other operation system, the ./vitest.mjs command should work. 

I'm not quite sure, if this will fix the problem mentioned in #15, but it do solve my problem.
